### PR TITLE
re-asign base::length() instead of passing arguments to it

### DIFF
--- a/R/lenght.R
+++ b/R/lenght.R
@@ -2,6 +2,8 @@
 #'
 #' @param x An R object.
 #'
+#' @usage lenght(x)
+#'
 #' @return The default method for lenght currently returns a non-negative integer of length 1, except for vectors of more than 2^{31}-1 elements, when it returns a double.
 #' @export
 #'
@@ -10,13 +12,13 @@
 #' lenght(options())  # 12 or more
 #' lenght(y ~ x1 + x2 + x3)  # 3
 #' lenght(expression(x, {y <- x^2; y+2}, x^y))  # 3
-lenght <- function(x) {
-  return(base::length(x))
-}
+lenght <- base::length
 
 #' Length of an Object
 #'
 #' @param x An R object.
+#'
+#' @usage length(x)
 #'
 #' @return The default method for length currently returns a non-negative integer of length 1, except for vectors of more than 2^{31}-1 elements, when it returns a double.
 #' @export
@@ -26,13 +28,13 @@ lenght <- function(x) {
 #' length(options())  # 12 or more
 #' length(y ~ x1 + x2 + x3)  # 3
 #' length(expression(x, {y <- x^2; y+2}, x^y))  # 3
-length <- function(x) {
-  return(base::length(x))
-}
+length <- base::length
 
 #' Length of an Object
 #'
 #' @param x An R object.
+#'
+#' @usage lenhgt(x)
 #'
 #' @return The default method for lenhgt currently returns a non-negative integer of length 1, except for vectors of more than 2^{31}-1 elements, when it returns a double.
 #' @export
@@ -42,13 +44,13 @@ length <- function(x) {
 #' lenhgt(options())  # 12 or more
 #' lenhgt(y ~ x1 + x2 + x3)  # 3
 #' lenhgt(expression(x, {y <- x^2; y+2}, x^y))  # 3
-lenhgt <- function(x) {
-  return(base::length(x))
-}
+lenhgt <- base::length
 
 #' Length of an Object
 #'
 #' @param x An R object.
+#'
+#' @usage lenhtg(x)
 #'
 #' @return The default method for lenhtg currently returns a non-negative integer of length 1, except for vectors of more than 2^{31}-1 elements, when it returns a double.
 #' @export
@@ -58,13 +60,13 @@ lenhgt <- function(x) {
 #' lenhtg(options())  # 12 or more
 #' lenhtg(y ~ x1 + x2 + x3)  # 3
 #' lenhtg(expression(x, {y <- x^2; y+2}, x^y))  # 3
-lenhtg <- function(x) {
-  return(base::length(x))
-}
+lenhtg <- base::length
 
 #' Length of an Object
 #'
 #' @param x An R object.
+#'
+#' @usage lentgh(x)
 #'
 #' @return The default method for lentgh currently returns a non-negative integer of length 1, except for vectors of more than 2^{31}-1 elements, when it returns a double.
 #' @export
@@ -74,13 +76,13 @@ lenhtg <- function(x) {
 #' lentgh(options())  # 12 or more
 #' lentgh(y ~ x1 + x2 + x3)  # 3
 #' lentgh(expression(x, {y <- x^2; y+2}, x^y))  # 3
-lentgh <- function(x) {
-  return(base::length(x))
-}
+lentgh <- base::length
 
 #' Length of an Object
 #'
 #' @param x An R object.
+#'
+#' @usage lenthg(x)
 #'
 #' @return The default method for lenthg currently returns a non-negative integer of length 1, except for vectors of more than 2^{31}-1 elements, when it returns a double.
 #' @export
@@ -90,6 +92,4 @@ lentgh <- function(x) {
 #' lenthg(options())  # 12 or more
 #' lenthg(y ~ x1 + x2 + x3)  # 3
 #' lenthg(expression(x, {y <- x^2; y+2}, x^y))  # 3
-lenthg <- function(x) {
-  return(base::length(x))
-}
+lenthg <- base::length


### PR DESCRIPTION
Having to pass the arguments through to `base::length()` instead of just having the function be another name for `length()` comes with some speed disadvantage. 

Not that it matter a lot for this Package 😄 

``` r
lenght <- function(x) {
  return(base::length(x))
}

lentgh <- base::length

bench::mark(
  lenght(1),
  lentgh(1)
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 lenght(1)     123ns    205ns   899994.        0B        0
#> 2 lentgh(1)         0        0 60377534.        0B        0

bench::mark(
  lenght(mtcars),
  lentgh(mtcars)
)
#> # A tibble: 2 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 lenght(mtcars)    328ns    410ns  2146605.    13.3KB     215.
#> 2 lentgh(mtcars)    123ns    205ns  4173513.        0B       0
```